### PR TITLE
Base url fix

### DIFF
--- a/getchromium.sh
+++ b/getchromium.sh
@@ -11,7 +11,7 @@ die() {
 
 W=`whoami`
 TMP="/tmp"
-BASE_URL="http://build.chromium.org/buildbot/snapshots/chromium-rel-mac"
+BASE_URL="http://build.chromium.org/f/chromium/snapshots/chromium-rel-mac/"
 ARCHIVE_NAME="chrome-mac.zip"
 LATEST_URL="$BASE_URL/LATEST"
 LATEST_VERSION=`curl -s -f $LATEST_URL` || die "Unable to fetch latest version number"


### PR DESCRIPTION
Thanks for the great script! 

Google have updated the URL used in the BASE_URL variable so I was getting a 301 redirect and the script was failing. 

I've updated BASE_URL to the correct location in this branch.
