### PR TITLE
Getting installed version through OSX's buit in defaults.

### DIFF
--- a/getchromium.sh
+++ b/getchromium.sh
@@ -18,7 +18,7 @@ LATEST_VERSION=`curl -s -f $LATEST_URL` || die "Unable to fetch latest version n
 PROC=`ps aux|grep -i Chromium|grep -iv grep|grep -iv $0|wc -l|awk '{print $1}'` || die "Unable to count running Chromium processes"
 INSTALL_DIR="/Applications"
 # Using Chromium's Info.plist to get the SVN Revision.
-INSTALLED_VERSION=`defaults read $INSTALL_DIR/Chromium2.app/Contents/Info SVNRevision 2>/dev/null`
+INSTALLED_VERSION=`defaults read $INSTALL_DIR/Chromium.app/Contents/Info SVNRevision 2>/dev/null`
 
 # The script should never be run by root
 if [[ $W == "root" ]]; then


### PR DESCRIPTION
Hi there,
I modified it to read/get the installed Chromium version through Chromium's Info.plist SVNRevision key: 
    <key>SVNRevision</key>
    <string>64542</string>
i.e
    defaults read /Applications/Chromium.app/Contents/Info SVNRevision
Alternatively, you could read this same info with PlistBuddy: 
    /usr/libexec/PlistBuddy -c "Print SVNRevision" /Applications/Chromium.app/Contents/Info.plist 
...but the location of PlistBuddy may vary in older versions of OSX. 
