### PR TITLE
Fix base url to download Chromium package.

### DIFF
--- a/getchromium.sh
+++ b/getchromium.sh
@@ -13,8 +13,7 @@ die() {
 
 W="$(whoami)"
 TMP="${TMPDIR-/tmp}"
-#BASE_URL='https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac'
-BASE_URL='https://storage.googleapis.com/chromium-qa/Chromium_Mac_10_8_x64__experimental_'
+BASE_URL='https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac'
 ARCHIVE_NAME='chrome-mac.zip'
 LATEST_URL="${BASE_URL}/LAST_CHANGE"
 LATEST_VERSION="$(curl -s -f "$LATEST_URL")" || die 'Unable to fetch latest version number from %s' "$LATEST_URL"


### PR DESCRIPTION
The `BASE_URL` does not indicate latest chromium :sob: 

- https://storage.googleapis.com/chromium-qa/Chromium_Mac_10_8_x64__experimental_/LAST_CHANGE shows `308973`
- https://commondatastorage.googleapis.com/chromium-browser-snapshots/Mac/LAST_CHANGE shows `354680`

I think current `BASE_URL` is dead url path.
If this suggestion is declined, I will start to maintain this script in my forked repository.